### PR TITLE
Position player correctly on level load

### DIFF
--- a/app/World/World.hs
+++ b/app/World/World.hs
@@ -14,7 +14,7 @@ type Coordinate = (Int, Int)
 type World = [Level]
 
 data Direction = North | East | South | West
-data VerticalDirection = Upwards | Downwards
+data VerticalDirection = Upwards | Downwards deriving (Eq)
 data Cell
     = Door
     | Empty
@@ -22,6 +22,7 @@ data Cell
     | Stair VerticalDirection
     | Tunnel
     | Wall
+    deriving (Eq)
 
 instance Show Cell where
     show (Stair Downwards) = "V "

--- a/app/World/WorldGeneration.hs
+++ b/app/World/WorldGeneration.hs
@@ -163,7 +163,7 @@ create width height = do
         allWalls = listArray boundingRectangle (repeat Wall)
     flip fix initial $ \loop tree -> do
         tree' <- split tree
-        if leaves tree' <= 40
+        if leaves tree' <= 6
             then loop tree'
             else do
                 tree'' <- shrinkWalls tree'


### PR DESCRIPTION
There are three features in this PR:

- When the game loads, the player is placed on the unique cell where there is a `Stair Upwards`
- When the player proceeds to the next level, they are positioned at the new level's cell where there is a `Stair Upwards`
- When the player walks into the `Stair Upwards` cell on level 0, nothing happens